### PR TITLE
Support for timestamps and HTML responses

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,12 @@
+(ns user
+  (:require [civ6hook.core :as cc]))
+
+(defn start []
+  (cc/start))
+
+(defn stop []
+  (cc/stop))
+
+(defn restart []
+  (stop)
+  (start))

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [com.draines/postal "2.0.3"]
                  [compojure "1.6.1"]
                  [ring/ring-defaults "0.3.2"]
-                 [ring/ring-json "0.4.0"]]
+                 [ring/ring-json "0.4.0"]
+                 [clojure.java-time "0.3.2"]]
 
   :plugins [[lein-ring "0.12.5"]]
 

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,19 @@
                  [compojure "1.6.1"]
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-json "0.4.0"]
-                 [clojure.java-time "0.3.2"]]
+                 [clojure.java-time "0.3.2"]
+                 [ring/ring-jetty-adapter "1.7.1"]
+                 [mount "0.1.16"]
+                 [com.taoensso/timbre "4.10.0"]]
 
   :plugins [[lein-ring "0.12.5"]]
 
   :ring {:handler civ6hook.handler/app
-         :init civ6hook.settings/read-settings!}
+         :init    civ6hook.core/start-for-lein-ring}
 
-  :profiles
-  {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                        [ring/ring-mock "0.3.2"]]}})
+  :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
+                                  [ring/ring-mock "0.3.2"]]
+                   :source-paths ["dev"]
+                   :main         user}}
+
+  :main civ6hook.core)

--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,11 @@
                  [compojure "1.6.1"]
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-json "0.4.0"]
-                 [clojure.java-time "0.3.2"]
+                 [ring-middleware-accept "2.0.3"]
                  [ring/ring-jetty-adapter "1.7.1"]
+                 [clojure.java-time "0.3.2"]
                  [mount "0.1.16"]
+                 [hiccup "1.0.5"]
                  [com.taoensso/timbre "4.10.0"]]
 
   :plugins [[lein-ring "0.12.5"]]

--- a/src/civ6hook/core.clj
+++ b/src/civ6hook/core.clj
@@ -12,7 +12,7 @@
                   (.writeString jsonGenerator (jt/format "yyyy-MM-dd'T'HH:mm:ssZ" c))))
 
 (m/defstate server
-  :start (let [server (jetty/run-jetty api/app {:join? false :port 3000})]
+  :start (let [server (jetty/run-jetty #'api/app {:join? false :port 3000})]
            (log/info "Server running")
            server)
   :stop  (do

--- a/src/civ6hook/core.clj
+++ b/src/civ6hook/core.clj
@@ -1,0 +1,32 @@
+(ns civ6hook.core
+  (:require [civ6hook.handler :as api]
+            [ring.adapter.jetty :as jetty]
+            [mount.core :as m]
+            [taoensso.timbre :as log]
+            [cheshire.generate :as cg]
+            [java-time :as jt]
+            [civ6hook.settings]))
+
+(cg/add-encoder java.time.ZonedDateTime
+                (fn [c jsonGenerator]
+                  (.writeString jsonGenerator (jt/format "yyyy-MM-dd'T'HH:mm:ssZ" c))))
+
+(m/defstate server
+  :start (let [server (jetty/run-jetty api/app {:join? false :port 3000})]
+           (log/info "Server running")
+           server)
+  :stop  (do
+           (.stop server)
+           (log/info "Server stopped")))
+
+(defn start-for-lein-ring []
+  (m/start-without #'server))
+
+(defn start []
+  (m/start))
+
+(defn stop []
+  (m/stop))
+
+(defn -main [& args]
+  (start))

--- a/src/civ6hook/handler.clj
+++ b/src/civ6hook/handler.clj
@@ -6,6 +6,7 @@
             [compojure.core :refer :all]
             [compojure.route :as route]
             [postal.core :as postal]
+            [taoensso.timbre :as log]
             [ring.middleware.defaults :refer [wrap-defaults]]
             [ring.middleware.json :refer [wrap-json-body wrap-json-response]]
             [ring.util.response :refer [response file-response not-found content-type]]))
@@ -31,7 +32,7 @@
 (defn unknown-player
   "Log but still return OK to webhook caller"
   [player]
-  (println (str "Unknown player " player))
+  (log/warn (str "Unknown player " player))
   "OK")
 
 (defn handle-turn [{:keys [value1 value2 value3]}]

--- a/src/civ6hook/settings.clj
+++ b/src/civ6hook/settings.clj
@@ -1,11 +1,17 @@
 (ns civ6hook.settings
-  (:require [clojure.edn :as edn]))
+  (:require [clojure.edn :as edn]
+            [mount.core :as m]
+            [taoensso.timbre :as log]))
 
-(def settings (atom {}))
+(defn- read-settings []
+  (edn/read-string (slurp "settings.edn")))
+
+(m/defstate settings
+  :start (atom (read-settings)))
 
 (defn read-settings! []
-  (println "Reading settings")
-  (reset! settings (edn/read-string (slurp "settings.edn"))))
+  (log/info "Reading settings")
+  (reset! settings (read-settings)))
 
 (defn email-settings []
   (:email @settings))

--- a/src/civ6hook/stats.clj
+++ b/src/civ6hook/stats.clj
@@ -1,7 +1,9 @@
 (ns civ6hook.stats
-  (:require [java-time :as jt]))
+  (:require [java-time :as jt]
+            [mount.core :as m]))
 
-(def db (atom {}))
+(m/defstate db
+  :start (atom {}))
 
 (defn- set-game-state! [game state]
   (swap! db assoc game state))

--- a/src/civ6hook/stats.clj
+++ b/src/civ6hook/stats.clj
@@ -1,12 +1,15 @@
-(ns civ6hook.stats)
+(ns civ6hook.stats
+  (:require [java-time :as jt]))
 
 (def db (atom {}))
 
 (defn- set-game-state! [game state]
   (swap! db assoc game state))
 
+(defn set-current-player-and-turn! [game player turn]
+  (set-game-state! game {:player player
+                         :turn turn
+                         :timestamp (jt/zoned-date-time (jt/system-clock "UTC"))}))
+
 (defn get-game-states []
   @db)
-
-(defn set-current-player-and-turn! [game player turn]
-  (set-game-state! game {:player player :turn turn}))

--- a/src/civ6hook/stats.clj
+++ b/src/civ6hook/stats.clj
@@ -1,5 +1,6 @@
 (ns civ6hook.stats
   (:require [java-time :as jt]
+            [hiccup.core :as h]
             [mount.core :as m]))
 
 (m/defstate db
@@ -13,5 +14,19 @@
                          :turn turn
                          :timestamp (jt/zoned-date-time (jt/system-clock "UTC"))}))
 
+(defn html-render [data]
+  (h/html
+    (for [[game-name game-data] @db]
+      [:div.game
+       [:h1 game-name]
+       [:p (format "Current player in turn: %s" (:player game-data))]
+       [:p (format "It's turn %s, last turn committed at %s"
+                   (:turn game-data)
+                   (jt/format
+                     "dd.MM.yyyy HH:mm"
+                     (jt/offset-date-time
+                       (:timestamp game-data)
+                       (jt/zone-id "Europe/Helsinki"))))]])))
+
 (defn get-game-states []
-  @db)
+  (with-meta @db {:render {"text/html" html-render}}))


### PR DESCRIPTION
Add support for HTML responses based on HTTP `Accept` header. Also adds timestamp when the last turn was made.

In addition to these, support for "REPL-driven" development. This means that one can simply start `lein repl` and do everything from there. No need for plugins or whatever. In addition to these, modified state handling to use mount to ease REPL development.